### PR TITLE
Register application menu into desktop environment

### DIFF
--- a/com.getpostman.Postman.appdata.xml
+++ b/com.getpostman.Postman.appdata.xml
@@ -25,7 +25,7 @@
   </screenshots>
   <url type="homepage">https://www.getpostman.com</url>
   <releases>
-    <release version="7.21.1" date="2020-03-24" />
+    <release version="7.22.1" date="2020-04-08" />
   </releases>
   <content_rating type="oars-1.1" />
 </component>

--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -12,6 +12,7 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --filesystem=home
+  - --talk-name=com.canonical.AppMenu.Registrar
 modules:
   - name: Postman
     buildsystem: simple

--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -39,9 +39,9 @@ modules:
       - type: extra-data
         only-arches:
           - x86_64
-        url: https://dl.pstmn.io/download/version/7.21.1/linux64
-        sha256: 9198c63958daaa12d2ba25af46151367a553c9d1265dfa691118415a9660a41a
-        size: 81558088
+        url: https://dl.pstmn.io/download/version/7.22.1/linux64
+        sha256: 6941cc5772db6ed6519f4b26119cc53f30135665ae28f5c7435bab58a9f650b6
+        size: 81013075
         filename: Postman.tar.gz
       - type: script
         dest-filename: run.sh


### PR DESCRIPTION
Currently, the application doesn't register the menu into my desktop environment, so I added an additional finish-arg as it was stated in [Octave issue](https://github.com/flathub/org.octave.Octave/issues/6)
Also, updated the application version to 7.22.1