### PR TITLE
Version 9.0.3

### DIFF
--- a/com.getpostman.Postman.appdata.xml
+++ b/com.getpostman.Postman.appdata.xml
@@ -25,6 +25,7 @@
   </screenshots>
   <url type="homepage">https://www.postman.com</url>
   <releases>
+    <release version="9.0.3" date="2021-09-26"/>
     <release version="8.12.4" date="2021-10-01"/>
     <release version="8.11.1" date="2021-09-20"/>
     <release version="8.10.0" date="2021-08-05"/>

--- a/com.getpostman.Postman.appdata.xml
+++ b/com.getpostman.Postman.appdata.xml
@@ -20,7 +20,7 @@
   </description>
   <screenshots>
     <screenshot type="default">
-      <image>https://assets.postman.com/postman-docs/postman-app-default-v8.jpg</image>
+      <image>https://assets.postman.com/postman-docs/postman-app-default-v9.jpg</image>
     </screenshot>
   </screenshots>
   <url type="homepage">https://www.postman.com</url>

--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -39,9 +39,9 @@ modules:
       - type: extra-data
         only-arches:
           - x86_64
-        url: https://dl.pstmn.io/download/version/8.12.4/linux64
-        sha256: bad325b0cf194cc38a6b00c7cc847c4edbae623a00bdec688f66af9f8b81927c
-        size: 133109349
+        url: https://dl.pstmn.io/download/version/9.0.3/linux64
+        sha256: 4b23aea34d7730a270cb19a12c696d402675888ef1be4837045235d31162a45b
+        size: 129557197
         x-checker-data:
           type: json
           url: https://dl.pstmn.io/api/version/latest?platform=linux64&channel=stable

--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -1,4 +1,5 @@
 app-id: com.getpostman.Postman
+branch: beta
 runtime: org.freedesktop.Platform
 runtime-version: '21.08'
 sdk: org.freedesktop.Sdk

--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -40,8 +40,8 @@ modules:
         only-arches:
           - x86_64
         url: https://dl.pstmn.io/download/version/9.0.3/linux64
-        sha256: 4b23aea34d7730a270cb19a12c696d402675888ef1be4837045235d31162a45b
-        size: 129557197
+        sha256: b3c104d82c8daa46430963c58f3038b875048c5848e31af6b12b4f25a3f74681
+        size: 133304468
         x-checker-data:
           type: json
           url: https://dl.pstmn.io/api/version/latest?platform=linux64&channel=stable


### PR DESCRIPTION
Release v9.x to the beta channel for now until upstream officially announce its availability for all platforms.

Closes #126
Closes #129