### PR TITLE
Add zypak-wrapper.sh for run script

### DIFF
--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -52,7 +52,7 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
-          - exec env TMPDIR=$XDG_CACHE_HOME /app/extra/Postman/Postman "$@"
+          - zypak-wrapper.sh /app/extra/Postman/Postman "$@"
       - type: file
         path: com.getpostman.Postman.desktop
       - type: file

--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -52,6 +52,7 @@ modules:
       - type: script
         dest-filename: run.sh
         commands:
+          - export TMPDIR="$XDG_CACHE_HOME"
           - zypak-wrapper.sh /app/extra/Postman/Postman "$@"
       - type: file
         path: com.getpostman.Postman.desktop


### PR DESCRIPTION
Fixes #187.

Zypak is [recommended for Electron apps](https://docs.flatpak.org/en/latest/electron.html#launching-the-app) and handles various Chromium sandboxing oddities and "relaunches".

With this fix I successfully managed to open `postman://` link from Chrome without Postman crashing. Sadly I couldn't do it from Firefox but I don't think it's related to this flatpak at all.