### PR TITLE
Use newer freedesktop platform 23.08

### DIFF
--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -1,9 +1,9 @@
 app-id: com.getpostman.Postman
 runtime: org.freedesktop.Platform
-runtime-version: '22.08'
+runtime-version: '23.08'
 sdk: org.freedesktop.Sdk
 base: org.electronjs.Electron2.BaseApp
-base-version: '22.08'
+base-version: '23.08'
 command: Postman
 separate-locales: false
 tags:


### PR DESCRIPTION
A new version of the runtime was recently released, see [here](https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/releases/freedesktop-sdk-23.08.0). Brings some updated packages, but they probably won't affect Postman.