### PR TITLE
Add Wayland Support

### DIFF
--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -10,8 +10,8 @@ tags:
   - proprietary
 finish-args:
   - --share=ipc
-  - --socket=x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --socket=pulseaudio
   - --share=network
   - --device=dri

--- a/com.getpostman.Postman.yaml
+++ b/com.getpostman.Postman.yaml
@@ -11,6 +11,7 @@ tags:
 finish-args:
   - --share=ipc
   - --socket=x11
+  - --socket=wayland
   - --socket=pulseaudio
   - --share=network
   - --device=dri


### PR DESCRIPTION
Request to change default permissions from X11 socket to Wayland socket and X11 fallback socket, because I experienced some bugs when launching in X11 mode on GNOME Wayland. Thanks!